### PR TITLE
Margin fix

### DIFF
--- a/src/Space.tsx
+++ b/src/Space.tsx
@@ -25,7 +25,7 @@ const Space: React.FC<{
         {
           height: 1,
           width: 1,
-          margin: typeof size === "number" ? size : sizes[size],
+          margin: typeof size === "number" ? size / 2 : sizes[size],
         },
         style,
       ]}


### PR DESCRIPTION
Now when margin passed as a number, then it gets divided by 2 in order for component to take the exact space defined by passed number